### PR TITLE
Chunk class family for pagination and sorting

### DIFF
--- a/src/Mongator/Query/Chunk.php
+++ b/src/Mongator/Query/Chunk.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Mongator\Query;
+
+class Chunk implements ChunkInterface
+{
+    public $sortFields;
+    public $page;
+    public $pageSize;
+
+    public function __construct($sortFields = null, $page = null, $pageSize = null)
+    {
+        $this->set($sortFields, $page, $pageSize);
+    }
+
+    public function set($sortFields, $page, $pageSize)
+    {
+        if (($sortFields !== null) && !is_array($sortFields))
+            $sortFields = array($sortFields => 1);
+
+        $this->sortFields = $sortFields;
+        $this->page = $page;
+        $this->pageSize = $pageSize;
+
+        return $this;
+    }
+
+    public function getResult(Query $query)
+    {
+        $this->applyTo($query);
+
+        $result = new ChunkResult($query->all());
+        $result->setTotal(function() use ($query) {
+            return $query->count();
+        });
+
+        return $result;
+    }
+
+    private function applyTo(Query $query)
+    {
+        if ($this->sortFields !== null)
+            $query->sort($this->sortFields);
+
+        if ($this->page !== null)
+            $query
+                ->skip($this->pageSize * $this->page)
+                ->limit($this->pageSize);
+
+        return $query;
+    }
+
+    private function applySort($query)
+    {
+        if ($this->sortFields === null) return $query;
+        return $query->sort($this->sortFields);
+    }
+}

--- a/src/Mongator/Query/Chunk.php
+++ b/src/Mongator/Query/Chunk.php
@@ -29,7 +29,7 @@ class Chunk implements ChunkInterface
     {
         $this->applyTo($query);
 
-        $result = new ChunkResult($query->all());
+        $result = $this->createChunkResult($query->all());
         $result->setTotal(function() use ($query) {
             return $query->count();
         });
@@ -48,6 +48,11 @@ class Chunk implements ChunkInterface
                 ->limit($this->pageSize);
 
         return $query;
+    }
+
+    protected function createChunkResult($data)
+    {
+        return new ChunkResult($data);
     }
 
     private function applySort($query)

--- a/src/Mongator/Query/ChunkInterface.php
+++ b/src/Mongator/Query/ChunkInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Mongator\Query;
+
+interface ChunkInterface
+{
+    public function getResult(Query $query);
+    public function set($sortStrategy, $page, $pageSize);
+}

--- a/src/Mongator/Query/ChunkResult.php
+++ b/src/Mongator/Query/ChunkResult.php
@@ -1,0 +1,22 @@
+<?php
+namespace Mongator\Query;
+
+class ChunkResult extends \ArrayObject
+{
+    private $total;
+
+    public function setTotal($total)
+    {
+        $this->total = $total;
+    }
+
+    public function getData() { return $this->getArrayCopy(); }
+    public function getTotal()
+    {
+        if ($this->total instanceOf \Closure) {
+            $this->total = $this->total->__invoke();
+        }
+
+        return $this->total;
+    }
+}

--- a/src/Mongator/Query/LocalChunk.php
+++ b/src/Mongator/Query/LocalChunk.php
@@ -76,7 +76,7 @@ abstract class LocalChunk implements ChunkInterface
         list($total, $selectedIds) = $this->getSelectedIds($query);
         $data = $this->findByIds($query, $selectedIds);
 
-        $result = new ChunkResult($data);
+        $result = $this->createChunkResult($data);
         $result->setTotal($total);
 
         return $result;
@@ -201,5 +201,10 @@ abstract class LocalChunk implements ChunkInterface
         foreach ($ids as $id) $data[] = $selected[(string) $id];
 
         return $data;
+    }
+
+    protected function createChunkResult($data)
+    {
+        return new ChunkResult($data);
     }
 }

--- a/src/Mongator/Query/LocalChunk.php
+++ b/src/Mongator/Query/LocalChunk.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Mongator\Query;
+use ArrayObject;
+
+abstract class LocalChunk implements ChunkInterface
+{
+    protected $filterFuncName;
+    protected $filterFields;
+    protected $localSortingStrategies;
+
+    protected $page;
+    protected $pageSize;
+    protected $ordering = 1;
+    protected $valueFunc = null;
+    protected $fields = [];
+    protected $filterFunc = null;
+    protected $dbSortFields;
+    protected $cache = [];
+
+    public function set($sortStrategy, $page, $pageSize)
+    {
+        $this->setSortStrategy($sortStrategy);
+        $this->setPagination($page, $pageSize);
+
+        return $this;
+    }
+
+    public function setPagination($page, $pageSize)
+    {
+        $this->page = $page;
+        $this->pageSize = $pageSize;
+
+        return $this;
+    }
+
+    public function setSortStrategy($sortStrategy)
+    {
+        if (!is_array($sortStrategy)) $sortStrategy = [$sortStrategy => 1];
+        $this->sortStrategy = $sortStrategy;
+    }
+
+    private function setLocalSort($valueFunc, $ordering)
+    {
+        $this->ordering = $ordering;
+        $this->valueFunc = $valueFunc;
+
+        return $this;
+    }
+
+    protected function setDBSort($sortFields)
+    {
+        if (!is_array($sortFields)) $sortFields = [$sortFields => 1];
+        $this->dbSortFields = $sortFields;
+
+        return $this;
+    }
+
+    private function setFilter($filterFunc)
+    {
+        $this->filterFunc = $filterFunc;
+
+        return $this;
+    }
+
+    private function setFields(array $fields)
+    {
+        $this->fields = $fields;
+
+        return $this;
+    }
+
+    final public function getResult(Query $query)
+    {
+        $this->prepareForQuery();
+        list($total, $selectedIds) = $this->getSelectedIds($query);
+        $data = $this->findByIds($query, $selectedIds);
+
+        $result = new ChunkResult($data);
+        $result->setTotal($total);
+
+        return $result;
+    }
+
+    protected function prepareForQuery()
+    {
+        $sortField = array_keys($this->sortStrategy);
+        $sortField = $sortField[0];
+        if (isset($this->localSortingStrategies[$sortField])) {
+            list($valueFuncName, $fields) = $this->localSortingStrategies[$sortField];
+
+            $this->setFields(array_merge($this->filterFields, $fields));
+            $this->setLocalSort($valueFuncName, $this->sortStrategy[$sortField]);
+        } else {
+            $this->setFields($this->filterFields);
+            $this->setDBSort($this->sortStrategy);
+        }
+    }
+
+    protected function getSelectedIds(Query $query)
+    {
+        if ($this->valueFunc)
+            return $this->getLocallySelectedIds($query);
+        else
+            return $this->getDBSelectedIds($query);
+    }
+
+    protected function getLocallySelectedIds($query)
+    {
+        list($total, $elems) = $this->getLocallySortedIds($query);
+        $ids = $this->getPage($elems);
+
+        return [$total, $ids];
+
+    }
+
+    protected function getLocallySortedIds(Query $query)
+    {
+        $valuedElems = [];
+        $total = 0;
+
+        foreach ($this->getElems($query) as $id => $elem) {
+            if ($this->filterFuncName && !$this->{$this->filterFuncName}($elem)) continue;
+            $value = $this->{$this->valueFunc}($elem);
+
+            if ($value !== null) {
+                $valuedElems[$id] = $value * $this->ordering;
+                $total++;
+            }
+        }
+
+        asort($valuedElems, SORT_NUMERIC);
+
+        return [$total, array_keys($valuedElems)];
+    }
+
+    protected function getDBSelectedIds($query)
+    {
+        $query->sort($this->dbSortFields);
+        foreach (array_keys($this->dbSortFields) as $field) {
+            $query->mergeCriteria([$field => ['$exists' => 1]]);
+        }
+
+        $elems = $this->getElems($query);
+        $ids = [];
+
+        $all = !$this->pageSize;
+        $start = $this->page * $this->pageSize;
+        $end = $start + $this->pageSize;
+        $count = 0;
+        $total = 0;
+        foreach ($elems as $id => $elem) {
+            if ((!$this->filterFuncName) || $this->{$this->filterFuncName}($elem)) {
+                $total++;
+                if ($all || (($count >= $start) && ($count < $end))) {
+                    $ids[] = new \MongoId($id);
+                }
+                $count++;
+            }
+        }
+
+        return [$total, $ids];
+    }
+
+    public function setCacheStorage(ArrayObject $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    private function getElems(Query $query)
+    {
+        if ($this->fields) $query = $query->fields($this->fields);
+
+        $key = $query->generateKey();
+        if ( !isset($this->cache[$key]) ) {
+            $this->cache[$key] = [];
+            foreach ($query->execute() as $id => $record) {
+                $this->cache[$key][$id] = $record;
+            }
+        }
+
+        return $this->cache[$key];
+    }
+
+    protected function getPage($valuedElems)
+    {
+        if (!$this->pageSize) return array_values($valuedElems);
+
+        $selectedIds = array_values(
+            array_slice($valuedElems, $this->page * $this->pageSize, $this->pageSize)
+        );
+
+        return $selectedIds;
+    }
+
+    protected function findByIds($query, $ids)
+    {
+        $selected = $query->getRepository()->findById($ids);
+
+        $data = [];
+        foreach ($ids as $id) $data[] = $selected[(string) $id];
+
+        return $data;
+    }
+}


### PR DESCRIPTION
The ChunkInterface implementations provide pagination and sorting. The interesting part is the Localhunk, which makes it possible to do client-side sorting. Having the interface guarantees that from the point of view of whomever is doing the search, there is no difference between this and a "normal" mongodb sort+skip+limit.
