### PR TITLE
Avoid calling saveReferences recursively

### DIFF
--- a/src/Mongator/Document/AbstractDocument.php
+++ b/src/Mongator/Document/AbstractDocument.php
@@ -29,8 +29,8 @@ abstract class AbstractDocument
     public $data = array();
     protected $fieldsModified = array();
     protected $onceEnvents = array();
-    private $archive;
     protected $savingReferences = false;
+    private $archive;
 
     /**
      * Constructor.

--- a/src/Mongator/Document/AbstractDocument.php
+++ b/src/Mongator/Document/AbstractDocument.php
@@ -30,6 +30,7 @@ abstract class AbstractDocument
     protected $fieldsModified = array();
     protected $onceEnvents = array();
     private $archive;
+    protected $savingReferences = false;
 
     /**
      * Constructor.

--- a/src/Mongator/Extension/templates/Core/DocumentSaveReferences.php.twig
+++ b/src/Mongator/Extension/templates/Core/DocumentSaveReferences.php.twig
@@ -5,7 +5,10 @@
      */
     public function saveReferences()
     {
-        if ($this->savingReferences) return;
+        if ($this->savingReferences) {
+            return;
+        }
+
         $this->savingReferences = true;
 {# references one #}
 {% for name, reference in config_class.referencesOne %}

--- a/src/Mongator/Extension/templates/Core/DocumentSaveReferences.php.twig
+++ b/src/Mongator/Extension/templates/Core/DocumentSaveReferences.php.twig
@@ -5,6 +5,8 @@
      */
     public function saveReferences()
     {
+        if ($this->savingReferences) return;
+        $this->savingReferences = true;
 {# references one #}
 {% for name, reference in config_class.referencesOne %}
 {# not inherited #}
@@ -53,4 +55,5 @@
 {% endif %}
 {% endif %}
 {% endfor %}
+        $this->savingReferences = false;
     }

--- a/tests/Mongator/Tests/Extension/CoreDocumentTest.php
+++ b/tests/Mongator/Tests/Extension/CoreDocumentTest.php
@@ -372,8 +372,8 @@ class CoreDocumentTest extends TestCase
 
         $one->save();
 
-        $this->assertTrue($one->getId() && !$one->isModified());
-        $this->assertTrue($two->getId() && !$two->isModified());
+        $this->assertFalse($one->isNew() || $one->isModified());
+        $this->assertFalse($two->isNew() || $two->isModified());
     }
 
     public function testEmbeddedsOneSettersGetters()

--- a/tests/Mongator/Tests/Extension/CoreDocumentTest.php
+++ b/tests/Mongator/Tests/Extension/CoreDocumentTest.php
@@ -362,6 +362,20 @@ class CoreDocumentTest extends TestCase
         }
     }
 
+    public function testSaveReferencesWithCircularReference()
+    {
+        $one = $this->mongator->create('Model\CircularReference');
+        $two = $this->mongator->create('Model\CircularReference');
+
+        $one->setValue(1)->setOther($two);
+        $two->setValue(2)->setOther($one);
+
+        $one->save();
+
+        $this->assertTrue($one->getId() && !$one->isModified());
+        $this->assertTrue($two->getId() && !$two->isModified());
+    }
+
     public function testEmbeddedsOneSettersGetters()
     {
         $article = $this->mongator->create('Model\Article');

--- a/tests/config_classes.php
+++ b/tests/config_classes.php
@@ -460,4 +460,13 @@ return array(
             'categories' => array('class' => 'Model\Category'),
         ),
     ),
+
+    'Model\CircularReference' => array(
+        'fields' => array(
+            'value' => 'integer',
+        ),
+        'referencesOne' => array(
+            'other' => array('class' => 'Model\CircularReference'),
+        ),
+    ),
 );


### PR DESCRIPTION
This makes it possible to have circular references in documents without
creating an infinite loop when saving.
